### PR TITLE
Correción final selector de tipos

### DIFF
--- a/pokedex/assets/js/app.js
+++ b/pokedex/assets/js/app.js
@@ -129,6 +129,9 @@
         if (!this.value) return;
 
         switch (this.value) {
+        case ' ':
+            mostrarTodos()
+            break;
         case 'grass':
            filtrarPorTipo('grass');
            break;

--- a/pokedex/index.html
+++ b/pokedex/index.html
@@ -37,7 +37,7 @@
         <div class="row mb-4">
             <div class="col-md-6 offset-md-3">
             <select id="filtroTipo" class="form-select" style="max-width: 180px;">
-                <option value="">Filtrar por tipo</option>
+                <option value=" ">Filtrar por tipo</option>
                 <option value="grass">🌿 Planta</option>
                 <option value="fire">🔥 Fuego</option>
                 <option value="water">💧 Agua</option>


### PR DESCRIPTION
Añade selector que permite filtrar entre los 18 tipos de Pokémon, corrección para "mostrar todos" al seleccionar opción "base"; "Filtrar por tipo"